### PR TITLE
fixed issue caused by language not being a string

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+node_modules
+#!include:.gitignore

--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@
    L114 compiler service.
    @flow weak
 */
-const langID = 114;
 const path = require('path');
 const compiler = require('./lib/compile.js');
 const {
   AuthError,
+  createCloudFunction,
   createLambda,
   createValidateToken,
 } = require('@graffiticode/graffiticode-compiler-framework');
@@ -21,9 +21,11 @@ function isError(err) {
   return false;
 }
 
-const validateToken = createValidateToken({ lang: langID });
+const langID = 114;
+const language = `L${langID}`;
+const validateToken = createValidateToken({ lang: language });
 const compilerDefinition = {
-  language: langID,
+  language,
   compile: (code, data, config) => {
     return new Promise((resolve, reject) => {
       compiler.compile(code, data, (err, val) => {
@@ -45,3 +47,4 @@ const compilerDefinition = {
 };
 exports.compiler = compilerDefinition;
 exports.lambdaHandler = createLambda(compilerDefinition);
+exports.cloudFunctionHandler = createCloudFunction(compilerDefinition);


### PR DESCRIPTION
- added cloud function handler


this can be deployed to a google cloud project by running:
```bash
npm run build-dev
gcloud functions deploy L114 \
  --trigger-http \
  --runtime nodejs10 \
  --entry-point cloudFunctionHandler \
  --allow-unauthenticated
```